### PR TITLE
CORRECT BIT MASKING FOR INT CONVERSION TO FRACSEC

### DIFF
--- a/synchrophasor/frame.py
+++ b/synchrophasor/frame.py
@@ -392,7 +392,7 @@ class CommonFrame(metaclass=ABCMeta):
         leap_occ = bool(leap_occ)
         leap_pen = bool(leap_pen)
 
-        fr_seconds = frasec_int & (2**23-1)
+        fr_seconds = frasec_int & 0x00ffffff  # take only first 24 LSB bits
 
         return fr_seconds, leap_dir, leap_occ, leap_pen, time_quality
 


### PR DESCRIPTION
The 32bit fracsec is divided into two, 24bits for the count of fraction-of-second, and an 8bit quality flags.
This commit corrects a 23bit mask for a 24bit mask.